### PR TITLE
Fix a bug when parsing a list with line breaks 

### DIFF
--- a/src/parser/internal.ts
+++ b/src/parser/internal.ts
@@ -154,7 +154,11 @@ function parseList(
 ): SectionBlock {
   let index = 0;
   const contents = element.items.map(item => {
-    const paragraph = item.tokens[0] as marked.Tokens.Text;
+    let tokenIndex = 0;
+    if (item.tokens[0].type === 'space' && item.tokens[1]) {
+      tokenIndex = 1;
+    }
+    const paragraph = item.tokens[tokenIndex] as marked.Tokens.Text;
     if (!paragraph || paragraph.type !== 'text' || !paragraph.tokens?.length) {
       return paragraph?.text || '';
     }

--- a/test/parser.spec.ts
+++ b/test/parser.spec.ts
@@ -56,6 +56,27 @@ describe('parser', () => {
     expect(actual).toStrictEqual(expected);
   });
 
+  it('should parse a list with newline', async () => {
+    const tokens = marked.lexer(
+      `1.
+Monday
+2.
+Tuesday
+3.
+Wednesday`
+        .trim()
+        .split('\n')
+        .map(s => s.trim())
+        .join('\n')
+    );
+
+    const actual = parseBlocks(tokens);
+
+    const expected = [slack.section('1. Monday\n2. Tuesday\n3. Wednesday')];
+
+    expect(actual).toStrictEqual(expected);
+  });
+
   it('should parse images', () => {
     const tokens = marked.lexer('![alt](url "title")![](url)');
     const actual = parseBlocks(tokens);


### PR DESCRIPTION
Hello👋

I am using tryfabric/mack on Slack and I found a bug that I would like to fix with this PR. 

### Issue 
 
I have found that the code is not converting lists with line breaks correctly. For example: 

```
1.
Monday
2.
Tuesday
3.
Wednesday
```

The output of the conversion looks like this: 

```
\n\n
```

### Solution
 
I have fixed this issue by modifying the `parseList()` function. The issue was caused by the function returning an empty string when `tokens[0]` was empty, but the actual content could be in `tokens[1]`. 

The `tokens` array could look like this, with one `space` and one `text`: 

```
{
  "type": "list_item",
  "raw": "1.\na\n",
  "task": false,
  "loose": false,
  "text": "\na",
  "tokens": [
    {"type": "space", "raw": "\n"},
    {
      "type": "text",
      "raw": "a",
      "text": "a",
      "tokens": [{"type": "text", "raw": "a", "text": "a"}]
    }
  ]
}
```