### PR TITLE
Fix escaping for Slack

### DIFF
--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -126,4 +126,10 @@ if (a === 'hi') {
       expect(actual).toStrictEqual(expected);
     });
   });
+
+  it('should correctly escape text', async () => {
+    const actual = await markdownToBlocks('<>&\'""\'&><');
+    const expected = [slack.section('&lt;&gt;&amp;\'""\'&amp;&gt;&lt;')];
+    expect(actual).toStrictEqual(expected);
+  });
 });


### PR DESCRIPTION
Slack doesn't want all HTML entities escaped, only `&`, `<`, and `>`.
https://api.slack.com/reference/surfaces/formatting#escaping
> You shouldn't HTML entity-encode the entire text, as only the specific characters shown above will be decoded for display in Slack.

But `marked` seems to assume we want HTML output.

To work around this, override the tokenizer's `inlineText` method with one that only escapes those 3 characters.

This fixes the issue where `We've allocated` displays as `We&#39;ve allocated` in Slack.